### PR TITLE
give body parser higher limit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,9 @@ const app = express();
 const port = process.env.PORT || 3000;
 const relativeUrl = '/' + (process.env.RELATIVE_URL || '');
 
-app.use(bodyParser.json());
+app.use(bodyParser.json({
+  limit: '50mb'
+}));
 
 app.get(relativeUrl, (req, res) => {
   // TODO: show pages table


### PR DESCRIPTION
I get this error when I test the web hook in gitlab-ui

Hook executed successfully but returned HTTP 413 Error: request entity too large<br> &nbsp; &nbsp;at readStream (/home/pages/webhook/node_modules/raw-body/index.js:196:17)<br> &nbsp; &nbsp;at getRawBody (/home/pages/webhook/node_modules/raw-body/index.js:106:12)<br> &nbsp; &nbsp;at read (/home/pages/webhook/node_modules/body-parser/lib/read.js:76:3)<br> &nbsp; &nbsp;at jsonParser (/home/pages/webhook/node_modules/body-parser/lib/types/json.js:127:5)<br> &nbsp; &nbsp;at Layer.handle [as handle_request] (/home/pages/webhook/node_modules/express/lib/router/layer.js:95:5)<br> &nbsp; &nbsp;at trim_prefix (/home/pages/webhook/node_modules/express/lib/router/index.js:312:13)<br> &nbsp; &nbsp;at /home/pages/webhook/node_modules/express/lib/router/index.js:280:7<br> &nbsp; &nbsp;at Function.process_params (/home/pages/webhook/node_modules/express/lib/router/index.js:330:12)<br> &nbsp; &nbsp;at next (/home/pages/webhook/node_modules/express/lib/router/index.js:271:10)<br> &nbsp; &nbsp;at expressInit (/home/pages/webhook/node_modules/express/lib/middleware/init.js:33:5)